### PR TITLE
Policy Changes (Operator -> Manifest) 

### DIFF
--- a/pkg/render/testutils/expected_policies/ad-api.json
+++ b/pkg/render/testutils/expected_policies/ad-api.json
@@ -46,8 +46,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
-          "selector": "k8s-app == 'kube-dns'",
+          "namespaceSelector": "projectcalico.org/name == \"kube-system\"",
+          "selector": "k8s-app == \"kube-dns\"",
           "ports": [
             53
           ]

--- a/pkg/render/testutils/expected_policies/ad-api_ocp.json
+++ b/pkg/render/testutils/expected_policies/ad-api_ocp.json
@@ -46,8 +46,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -57,8 +57,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/ad-detectors.json
+++ b/pkg/render/testutils/expected_policies/ad-detectors.json
@@ -28,8 +28,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
-          "selector": "k8s-app == 'kube-dns'",
+          "namespaceSelector": "projectcalico.org/name == \"kube-system\"",
+          "selector": "k8s-app == \"kube-dns\"",
           "ports": [
             53
           ]

--- a/pkg/render/testutils/expected_policies/ad-detectors_ocp.json
+++ b/pkg/render/testutils/expected_policies/ad-detectors_ocp.json
@@ -28,8 +28,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -39,8 +39,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/alertmanager-mesh_ocp.json
+++ b/pkg/render/testutils/expected_policies/alertmanager-mesh_ocp.json
@@ -60,8 +60,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -71,8 +71,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/alertmanager_ocp.json
+++ b/pkg/render/testutils/expected_policies/alertmanager_ocp.json
@@ -29,8 +29,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -40,8 +40,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/apiserver_ocp.json
+++ b/pkg/render/testutils/expected_policies/apiserver_ocp.json
@@ -54,8 +54,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -65,8 +65,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/compliance-server_ocp.json
+++ b/pkg/render/testutils/expected_policies/compliance-server_ocp.json
@@ -54,8 +54,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -65,8 +65,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/compliance_managed.json
+++ b/pkg/render/testutils/expected_policies/compliance_managed.json
@@ -17,10 +17,13 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "services": {
-            "name": "kubernetes",
-            "namespace": "default"
-          }
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/compliance_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/compliance_managed_ocp.json
@@ -17,10 +17,13 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "services": {
-            "name": "kubernetes",
-            "namespace": "default"
-          }
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/compliance_unmanaged_ocp.json
+++ b/pkg/render/testutils/expected_policies/compliance_unmanaged_ocp.json
@@ -27,8 +27,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -38,8 +38,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/dex.json
+++ b/pkg/render/testutils/expected_policies/dex.json
@@ -75,7 +75,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "selector": "prometheus == 'calico-node-prometheus'",
           "namespaceSelector": "name == 'tigera-prometheus'"
         }
       }
@@ -85,8 +85,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
-          "selector": "k8s-app == 'kube-dns'",
+          "namespaceSelector": "projectcalico.org/name == \"kube-system\"",
+          "selector": "k8s-app == \"kube-dns\"",
           "ports": [
             53
           ]

--- a/pkg/render/testutils/expected_policies/dex_ocp.json
+++ b/pkg/render/testutils/expected_policies/dex_ocp.json
@@ -75,7 +75,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "selector": "prometheus == 'calico-node-prometheus'",
           "namespaceSelector": "name == 'tigera-prometheus'"
         }
       }
@@ -85,8 +85,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -96,8 +96,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/dpi_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/dpi_managed_ocp.json
@@ -38,16 +38,6 @@
         "protocol": "TCP",
         "destination": {
           "services": {
-            "namespace": "default",
-            "name": "openshift-dns"
-          }
-        }
-      },
-      {
-        "action": "Allow",
-        "protocol": "TCP",
-        "destination": {
-          "services": {
             "namespace": "tigera-guardian",
             "name": "tigera-guardian"
           }

--- a/pkg/render/testutils/expected_policies/dpi_unmanaged_ocp.json
+++ b/pkg/render/testutils/expected_policies/dpi_unmanaged_ocp.json
@@ -38,16 +38,6 @@
         "protocol": "TCP",
         "destination": {
           "services": {
-            "namespace": "default",
-            "name": "openshift-dns"
-          }
-        }
-      },
-      {
-        "action": "Allow",
-        "protocol": "TCP",
-        "destination": {
-          "services": {
             "namespace": "tigera-elasticsearch",
             "name": "tigera-secure-es-gateway-http"
           }

--- a/pkg/render/testutils/expected_policies/elastic-curator.json
+++ b/pkg/render/testutils/expected_policies/elastic-curator.json
@@ -11,8 +11,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
-          "selector": "k8s-app == 'kube-dns'",
+          "namespaceSelector": "projectcalico.org/name == \"kube-system\"",
+          "selector": "k8s-app == \"kube-dns\"",
           "ports": [
             53
           ]
@@ -28,12 +28,11 @@
           "selector": "k8s-app == 'tigera-secure-es-gateway'"
         },
         "protocol": "TCP",
-        "source": {
-        }
+        "source": {}
       }
     ],
     "order": 1,
-    "selector": "k8s-app == 'elastic-curator'",
+    "selector": "k8s-app == \"elastic-curator\"",
     "tier": "allow-tigera",
     "types": [
       "Ingress",

--- a/pkg/render/testutils/expected_policies/elastic-curator_ocp.json
+++ b/pkg/render/testutils/expected_policies/elastic-curator_ocp.json
@@ -11,8 +11,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -22,8 +22,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -39,12 +39,11 @@
           "selector": "k8s-app == 'tigera-secure-es-gateway'"
         },
         "protocol": "TCP",
-        "source": {
-        }
+        "source": {}
       }
     ],
     "order": 1,
-    "selector": "k8s-app == 'elastic-curator'",
+    "selector": "k8s-app == \"elastic-curator\"",
     "tier": "allow-tigera",
     "types": [
       "Ingress",

--- a/pkg/render/testutils/expected_policies/elastic-operator.json
+++ b/pkg/render/testutils/expected_policies/elastic-operator.json
@@ -17,8 +17,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
-          "selector": "k8s-app == 'kube-dns'",
+          "namespaceSelector": "projectcalico.org/name == \"kube-system\"",
+          "selector": "k8s-app == \"kube-dns\"",
           "ports": [
             53
           ]

--- a/pkg/render/testutils/expected_policies/elastic-operator_ocp.json
+++ b/pkg/render/testutils/expected_policies/elastic-operator_ocp.json
@@ -17,8 +17,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -28,8 +28,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/elasticsearch_ocp.json
+++ b/pkg/render/testutils/expected_policies/elasticsearch_ocp.json
@@ -68,8 +68,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -79,8 +79,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/es-gateway_ocp.json
+++ b/pkg/render/testutils/expected_policies/es-gateway_ocp.json
@@ -211,8 +211,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -222,8 +222,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/es-kubecontrollers.json
+++ b/pkg/render/testutils/expected_policies/es-kubecontrollers.json
@@ -17,8 +17,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
-          "selector": "k8s-app == 'kube-dns'",
+          "namespaceSelector": "projectcalico.org/name == \"kube-system\"",
+          "selector": "k8s-app == \"kube-dns\"",
           "ports": [
             53
           ]

--- a/pkg/render/testutils/expected_policies/es-kubecontrollers_ocp.json
+++ b/pkg/render/testutils/expected_policies/es-kubecontrollers_ocp.json
@@ -17,8 +17,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -28,8 +28,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/es-metrics.json
+++ b/pkg/render/testutils/expected_policies/es-metrics.json
@@ -8,7 +8,7 @@
   "spec": {
     "tier": "allow-tigera",
     "order": 1,
-    "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
+    "selector": "k8s-app == \"tigera-elasticsearch-metrics\"",
     "serviceAccountSelector": "",
     "types": [
       "Ingress",
@@ -20,7 +20,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
-          "namespaceSelector": "name == 'tigera-prometheus'"
+          "namespaceSelector": "projectcalico.org/name == \"tigera-prometheus\""
         },
         "destination": {
           "ports": [
@@ -33,11 +33,10 @@
       {
         "action": "Allow",
         "protocol": "TCP",
-        "source": {
-        },
+        "source": {},
         "destination": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "projectcalico.org/name == \"tigera-elasticsearch\"",
           "ports": [
             "5554"
           ]
@@ -47,8 +46,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
-          "selector": "k8s-app == 'kube-dns'",
+          "namespaceSelector": "projectcalico.org/name == \"kube-system\"",
+          "selector": "k8s-app == \"kube-dns\"",
           "ports": [
             53
           ]

--- a/pkg/render/testutils/expected_policies/es-metrics_ocp.json
+++ b/pkg/render/testutils/expected_policies/es-metrics_ocp.json
@@ -8,7 +8,7 @@
   "spec": {
     "tier": "allow-tigera",
     "order": 1,
-    "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
+    "selector": "k8s-app == \"tigera-elasticsearch-metrics\"",
     "serviceAccountSelector": "",
     "types": [
       "Ingress",
@@ -20,7 +20,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
-          "namespaceSelector": "name == 'tigera-prometheus'"
+          "namespaceSelector": "projectcalico.org/name == \"tigera-prometheus\""
         },
         "destination": {
           "ports": [
@@ -33,11 +33,10 @@
       {
         "action": "Allow",
         "protocol": "TCP",
-        "source": {
-        },
+        "source": {},
         "destination": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "projectcalico.org/name == \"tigera-elasticsearch\"",
           "ports": [
             "5554"
           ]
@@ -47,8 +46,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -58,8 +57,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/fluentd_managed.json
+++ b/pkg/render/testutils/expected_policies/fluentd_managed.json
@@ -8,7 +8,7 @@
   "spec": {
     "tier": "allow-tigera",
     "order": 1,
-    "selector": "k8s-app == 'fluentd-node' || k8s-app == 'fluentd-node-windows'",
+    "selector": "k8s-app == \"fluentd-node\"",
     "types": [
       "Ingress",
       "Egress"
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
-          "namespaceSelector": "name == 'tigera-prometheus'"
+          "namespaceSelector": "projectcalico.org/name == \"tigera-prometheus\""
         },
         "destination": {
           "ports": [
@@ -32,11 +32,10 @@
       {
         "action": "Deny",
         "protocol": "TCP",
-        "source": {
-        },
+        "source": {},
         "destination": {
-          "selector": "k8s-app == 'tigera-guardian'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-guardian'",
+          "selector": "k8s-app == \"tigera-guardian\"",
+          "namespaceSelector": "projectcalico.org/name == \"tigera-guardian\"",
           "notPorts": [
             8080
           ]

--- a/pkg/render/testutils/expected_policies/fluentd_unmanaged.json
+++ b/pkg/render/testutils/expected_policies/fluentd_unmanaged.json
@@ -20,7 +20,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
-          "namespaceSelector": "name == 'tigera-prometheus'"
+          "namespaceSelector": "projectcalico.org/name == \"tigera-prometheus\""
         },
         "destination": {
           "ports": [
@@ -33,11 +33,10 @@
       {
         "action": "Deny",
         "protocol": "TCP",
-        "source": {
-        },
+        "source": {},
         "destination": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "projectcalico.org/name == \"tigera-elasticsearch\"",
           "notPorts": [
             5554
           ]
@@ -47,8 +46,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
-          "selector": "k8s-app == 'kube-dns'",
+          "namespaceSelector": "projectcalico.org/name == \"kube-system\"",
+          "selector": "k8s-app == \"kube-dns\"",
           "ports": [
             53
           ]

--- a/pkg/render/testutils/expected_policies/fluentd_unmanaged_ocp.json
+++ b/pkg/render/testutils/expected_policies/fluentd_unmanaged_ocp.json
@@ -20,7 +20,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
-          "namespaceSelector": "name == 'tigera-prometheus'"
+          "namespaceSelector": "projectcalico.org/name == \"tigera-prometheus\""
         },
         "destination": {
           "ports": [
@@ -37,7 +37,7 @@
         },
         "destination": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "projectcalico.org/name == \"tigera-elasticsearch\"",
           "notPorts": [
             5554
           ]
@@ -47,8 +47,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -58,8 +58,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/guardian.json
+++ b/pkg/render/testutils/expected_policies/guardian.json
@@ -23,8 +23,8 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-fluentd'",
-          "selector": "k8s-app == 'fluentd-node' || k8s-app == 'fluentd-node-windows'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-fluentd'",
+          "selector": "k8s-app == 'fluentd-node'"
         }
       },
       {
@@ -36,7 +36,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-compliance'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-benchmarker'"
         }
       },
@@ -49,7 +49,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-compliance'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-reporter'"
         }
       },
@@ -62,7 +62,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-compliance'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-snapshotter'"
         }
       },
@@ -75,7 +75,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-compliance'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-controller'"
         }
       },
@@ -131,8 +131,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
-          "selector": "k8s-app == 'kube-dns'",
+          "namespaceSelector": "projectcalico.org/name == \"kube-system\"",
+          "selector": "k8s-app == \"kube-dns\"",
           "ports": [
             53
           ]
@@ -155,24 +155,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "selector":"(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "selector": "prometheus == \"calico-node-prometheus\"",
           "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
           "ports": [
             9095
-          ]
-        }
-      },
-      {
-        "action": "Allow",
-        "protocol": "TCP",
-        "source": {
-        },
-        "destination": {
-          "nets": [
-            "127.0.0.1/32"
-          ],
-          "ports": [
-            1234
           ]
         }
       },

--- a/pkg/render/testutils/expected_policies/guardian_ocp.json
+++ b/pkg/render/testutils/expected_policies/guardian_ocp.json
@@ -23,8 +23,8 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-fluentd'",
-          "selector": "k8s-app == 'fluentd-node' || k8s-app == 'fluentd-node-windows'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-fluentd'",
+          "selector": "k8s-app == 'fluentd-node'"
         }
       },
       {
@@ -36,7 +36,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-compliance'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-benchmarker'"
         }
       },
@@ -49,7 +49,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-compliance'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-reporter'"
         }
       },
@@ -62,7 +62,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-compliance'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-snapshotter'"
         }
       },
@@ -75,7 +75,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-compliance'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-controller'"
         }
       },
@@ -131,8 +131,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -142,8 +142,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -166,24 +166,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "selector":"(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "selector": "prometheus == \"calico-node-prometheus\"",
           "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
           "ports": [
             9095
-          ]
-        }
-      },
-      {
-        "action": "Allow",
-        "protocol": "TCP",
-        "source": {
-        },
-        "destination": {
-          "nets": [
-            "127.0.0.1/32"
-          ],
-          "ports": [
-            1234
           ]
         }
       },

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed.json
@@ -41,8 +41,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
-          "selector": "k8s-app == 'kube-dns'",
+          "namespaceSelector": "projectcalico.org/name == \"kube-system\"",
+          "selector": "k8s-app == \"kube-dns\"",
           "ports": [
             53
           ]
@@ -52,8 +52,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "selector": "k8s-app == 'tigera-guardian'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-guardian'",
+          "selector": "k8s-app == \"tigera-guardian\"",
+          "namespaceSelector": "projectcalico.org/name == \"tigera-guardian\"",
           "ports": [
             8080
           ]

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed_ocp.json
@@ -41,8 +41,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -52,8 +52,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -63,8 +63,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "selector": "k8s-app == 'tigera-guardian'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-guardian'",
+          "selector": "k8s-app == \"tigera-guardian\"",
+          "namespaceSelector": "projectcalico.org/name == \"tigera-guardian\"",
           "ports": [
             8080
           ]

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_unmanaged.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_unmanaged.json
@@ -41,8 +41,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
-          "selector": "k8s-app == 'kube-dns'",
+          "namespaceSelector": "projectcalico.org/name == \"kube-system\"",
+          "selector": "k8s-app == \"kube-dns\"",
           "ports": [
             53
           ]

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_unmanaged_ocp.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_unmanaged_ocp.json
@@ -41,8 +41,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -52,8 +52,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/intrusion-detection-elastic.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-elastic.json
@@ -17,8 +17,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
-          "selector": "k8s-app == 'kube-dns'",
+          "namespaceSelector": "projectcalico.org/name == \"kube-system\"",
+          "selector": "k8s-app == \"kube-dns\"",
           "ports": [
             53
           ]

--- a/pkg/render/testutils/expected_policies/intrusion-detection-elastic_ocp.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-elastic_ocp.json
@@ -17,8 +17,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -28,8 +28,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/kibana.json
+++ b/pkg/render/testutils/expected_policies/kibana.json
@@ -73,11 +73,10 @@
       {
         "action": "Allow",
         "protocol": "TCP",
-        "source": {
-        },
+        "source": {},
         "destination": {
           "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "projectcalico.org/name == \"tigera-elasticsearch\"",
           "ports": [
             9200
           ]
@@ -87,8 +86,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
-          "selector": "k8s-app == 'kube-dns'",
+          "namespaceSelector": "projectcalico.org/name == \"kube-system\"",
+          "selector": "k8s-app == \"kube-dns\"",
           "ports": [
             53
           ]
@@ -111,7 +110,7 @@
             5554
           ],
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
         },
         "protocol": "TCP"
       }

--- a/pkg/render/testutils/expected_policies/kibana_ocp.json
+++ b/pkg/render/testutils/expected_policies/kibana_ocp.json
@@ -73,11 +73,10 @@
       {
         "action": "Allow",
         "protocol": "TCP",
-        "source": {
-        },
+        "source": {},
         "destination": {
           "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "projectcalico.org/name == \"tigera-elasticsearch\"",
           "ports": [
             9200
           ]
@@ -87,8 +86,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -98,8 +97,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -122,7 +121,7 @@
             5554
           ],
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
         },
         "protocol": "TCP"
       }

--- a/pkg/render/testutils/expected_policies/kubecontrollers.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers.json
@@ -17,8 +17,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
-          "selector": "k8s-app == 'kube-dns'",
+          "namespaceSelector": "projectcalico.org/name == \"kube-system\"",
+          "selector": "k8s-app == \"kube-dns\"",
           "ports": [
             53
           ]

--- a/pkg/render/testutils/expected_policies/kubecontrollers_managed.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers_managed.json
@@ -17,8 +17,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
-          "selector": "k8s-app == 'kube-dns'",
+          "namespaceSelector": "projectcalico.org/name == \"kube-system\"",
+          "selector": "k8s-app == \"kube-dns\"",
           "ports": [
             53
           ]

--- a/pkg/render/testutils/expected_policies/kubecontrollers_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers_managed_ocp.json
@@ -17,8 +17,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -28,8 +28,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/kubecontrollers_ocp.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers_ocp.json
@@ -17,8 +17,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -28,8 +28,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/manager.json
+++ b/pkg/render/testutils/expected_policies/manager.json
@@ -45,8 +45,7 @@
       {
         "action": "Allow",
         "protocol": "TCP",
-        "source": {
-        },
+        "source": {},
         "destination": {
           "ports": [
             9449
@@ -58,18 +57,7 @@
       {
         "action": "Allow",
         "protocol": "TCP",
-        "destination": {
-          "services": {
-            "name": "tigera-api",
-            "namespace": "tigera-system"
-          }
-        }
-      },
-      {
-        "action": "Allow",
-        "protocol": "TCP",
-        "source": {
-        },
+        "source": {},
         "destination": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
           "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
@@ -136,7 +124,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "selector": "prometheus == \"calico-node-prometheus\"",
           "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
           "ports": [
             9095

--- a/pkg/render/testutils/expected_policies/manager_ocp.json
+++ b/pkg/render/testutils/expected_policies/manager_ocp.json
@@ -45,8 +45,7 @@
       {
         "action": "Allow",
         "protocol": "TCP",
-        "source": {
-        },
+        "source": {},
         "destination": {
           "ports": [
             9449
@@ -58,18 +57,7 @@
       {
         "action": "Allow",
         "protocol": "TCP",
-        "destination": {
-          "services": {
-            "name": "tigera-api",
-            "namespace": "tigera-system"
-          }
-        }
-      },
-      {
-        "action": "Allow",
-        "protocol": "TCP",
-        "source": {
-        },
+        "source": {},
         "destination": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
           "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
@@ -125,8 +113,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -136,8 +124,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -147,7 +135,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "selector": "prometheus == \"calico-node-prometheus\"",
           "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
           "ports": [
             9095

--- a/pkg/render/testutils/expected_policies/packetcapture_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/packetcapture_managed_ocp.json
@@ -46,8 +46,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -57,8 +57,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/packetcapture_ocp.json
+++ b/pkg/render/testutils/expected_policies/packetcapture_ocp.json
@@ -46,8 +46,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -57,8 +57,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/prometheus-api.json
+++ b/pkg/render/testutils/expected_policies/prometheus-api.json
@@ -40,8 +40,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
-          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "selector": "prometheus == \"calico-node-prometheus\"",
           "ports": [
             9095
           ]

--- a/pkg/render/testutils/expected_policies/prometheus-api_ocp.json
+++ b/pkg/render/testutils/expected_policies/prometheus-api_ocp.json
@@ -29,8 +29,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -40,8 +40,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -51,8 +51,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
-          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "selector": "prometheus == \"calico-node-prometheus\"",
           "ports": [
             9095
           ]

--- a/pkg/render/testutils/expected_policies/prometheus-operator_ocp.json
+++ b/pkg/render/testutils/expected_policies/prometheus-operator_ocp.json
@@ -17,8 +17,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -28,8 +28,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]

--- a/pkg/render/testutils/expected_policies/prometheus_ocp.json
+++ b/pkg/render/testutils/expected_policies/prometheus_ocp.json
@@ -29,8 +29,8 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]
@@ -40,8 +40,8 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == \"openshift-dns\"",
+          "selector": "dns.operator.openshift.io/daemonset-dns == \"default\"",
           "ports": [
             5353
           ]


### PR DESCRIPTION
Use this PR to visualize the changes made by the `allow-tigera-reconciliation` branch to rendered policy.

The LHS of the diff view represents what policy looks like once rendered by the operator. The RHS represents the current state of policy, i.e. policy prior to operator.

The LHS is simply the test expectations that the render components use to validate all possible render scenarios. The RHS are the current policy manifests converted to JSON.